### PR TITLE
LibCrypto : BigInt performance improvements

### DIFF
--- a/Libraries/LibCrypto/BigInt/UnsignedBigInteger.cpp
+++ b/Libraries/LibCrypto/BigInt/UnsignedBigInteger.cpp
@@ -52,14 +52,17 @@ UnsignedBigInteger UnsignedBigInteger::import_data(const u8* ptr, size_t length)
 size_t UnsignedBigInteger::export_data(AK::ByteBuffer& data)
 {
     UnsignedBigInteger copy { *this };
+    UnsignedBigInteger quotient;
+    UnsignedBigInteger remainder;
 
     size_t size = trimmed_length() * sizeof(u32);
     size_t i = 0;
     for (; i < size; ++i) {
-        if (copy.length() == 0)
+        if (copy.trimmed_length() == 0)
             break;
         data[size - i - 1] = copy.m_words[0] & 0xff;
-        copy = copy.divided_by(256).quotient;
+        divide_u16_without_allocation(copy, 256, quotient, remainder);
+        copy.set_to(quotient);
     }
     return i;
 }
@@ -79,12 +82,14 @@ String UnsignedBigInteger::to_base10() const
 {
     StringBuilder builder;
     UnsignedBigInteger temp(*this);
+    UnsignedBigInteger quotient;
+    UnsignedBigInteger remainder;
 
     while (temp != UnsignedBigInteger { 0 }) {
-        auto div_result = temp.divided_by({ 10 });
-        ASSERT(div_result.remainder.words()[0] < 10);
-        builder.append(static_cast<char>(div_result.remainder.words()[0] + '0'));
-        temp = div_result.quotient;
+        divide_u16_without_allocation(temp, 10, quotient, remainder);
+        ASSERT(remainder.words()[0] < 10);
+        builder.append(static_cast<char>(remainder.words()[0] + '0'));
+        temp.set_to(quotient);
     }
 
     auto reversed_string = builder.to_string();
@@ -100,6 +105,13 @@ void UnsignedBigInteger::set_to_0()
 {
     m_words.clear_with_capacity();
     m_is_invalid = false;
+}
+
+void UnsignedBigInteger::set_to(u32 other)
+{
+    m_is_invalid = false;
+    m_words.clear_with_capacity();
+    m_words.append(other);
 }
 
 void UnsignedBigInteger::set_to(const UnsignedBigInteger& other)
@@ -167,6 +179,13 @@ FLATTEN UnsignedDivisionResult UnsignedBigInteger::divided_by(const UnsignedBigI
 {
     UnsignedBigInteger quotient;
     UnsignedBigInteger remainder;
+
+    // If we actually have a u16-compatible divisor, short-circuit to the
+    // less computationally-intensive "divide_u16_without_allocation" method.
+    if (divisor.trimmed_length() == 1 && divisor.m_words[0] < (1 << 16)) {
+        divide_u16_without_allocation(*this, divisor.m_words[0], quotient, remainder);
+        return UnsignedDivisionResult { quotient, remainder };
+    }
 
     UnsignedBigInteger temp_shift_result;
     UnsignedBigInteger temp_shift_plus;
@@ -407,7 +426,7 @@ FLATTEN void UnsignedBigInteger::divide_without_allocation(
 {
     quotient.set_to_0();
     remainder.set_to(numerator);
-
+    
     // iterate all bits
     for (int word_index = numerator.trimmed_length() - 1; word_index >= 0; --word_index) {
         for (int bit_index = UnsignedBigInteger::BITS_IN_WORD - 1; bit_index >= 0; --bit_index) {
@@ -421,6 +440,41 @@ FLATTEN void UnsignedBigInteger::divide_without_allocation(
             }
         }
     }
+}
+
+/**
+ * Complexity : O(N) where N is the number of digits in the numerator
+ * Division method :
+ * Starting from the most significant one, for each half-word of the numerator, combine it
+ * with the existing remainder if any, divide the combined number as a u32 operation and
+ * update the quotient / remainder as needed. 
+ */
+FLATTEN void UnsignedBigInteger::divide_u16_without_allocation(
+    const UnsignedBigInteger& numerator,
+    u32 denominator,
+    UnsignedBigInteger& quotient,
+    UnsignedBigInteger& remainder)
+{
+    ASSERT(denominator < (1 << 16));
+    u32 remainder_word = 0;
+    auto numerator_length = numerator.trimmed_length();
+    quotient.set_to_0();
+    quotient.m_words.resize(numerator_length);
+    for (int word_index = numerator_length - 1; word_index >= 0; --word_index) {
+        auto word_high = numerator.m_words[word_index] >> 16;
+        auto word_low = numerator.m_words[word_index] & ((1 << 16) - 1);
+
+        auto number_to_divide_high = (remainder_word << 16) | word_high;
+        auto quotient_high = number_to_divide_high / denominator;
+        remainder_word = number_to_divide_high % denominator;
+
+        auto number_to_divide_low = remainder_word << 16 | word_low;
+        auto quotient_low = number_to_divide_low / denominator;
+        remainder_word = number_to_divide_low % denominator;
+
+        quotient.m_words[word_index] = (quotient_high << 16) | quotient_low;
+    }
+    remainder.set_to(remainder_word);
 }
 
 ALWAYS_INLINE void UnsignedBigInteger::shift_left_by_n_words(

--- a/Libraries/LibCrypto/BigInt/UnsignedBigInteger.cpp
+++ b/Libraries/LibCrypto/BigInt/UnsignedBigInteger.cpp
@@ -96,6 +96,21 @@ String UnsignedBigInteger::to_base10() const
     return builder.to_string();
 }
 
+void UnsignedBigInteger::set_to_0()
+{
+    m_words.clear_with_capacity();
+    m_is_invalid = false;
+}
+
+void UnsignedBigInteger::set_to(const UnsignedBigInteger& other)
+{
+    m_is_invalid = other.m_is_invalid;
+    m_words.clear_with_capacity();
+    m_words.ensure_capacity(other.m_words.size());
+    for (size_t i = 0; i < other.m_words.size(); ++i)
+        m_words.unchecked_append(other.m_words[i]);
+}
+
 size_t UnsignedBigInteger::trimmed_length() const
 {
     size_t num_leading_zeroes = 0;
@@ -106,161 +121,61 @@ size_t UnsignedBigInteger::trimmed_length() const
     return length() - num_leading_zeroes;
 }
 
-/**
- * Complexity: O(N) where N is the number of words in the larger number
- */
-UnsignedBigInteger UnsignedBigInteger::plus(const UnsignedBigInteger& other) const
-{
-    const UnsignedBigInteger* const longer = (length() > other.length()) ? this : &other;
-    const UnsignedBigInteger* const shorter = (longer == &other) ? this : &other;
-    UnsignedBigInteger result;
-
-    u8 carry = 0;
-
-    result.m_words.ensure_capacity(longer->length() + 1);
-
-    for (size_t i = 0; i < shorter->length(); ++i) {
-        u32 word_addition_result = shorter->m_words[i] + longer->m_words[i];
-        u8 carry_out = 0;
-        // if there was a carry, the result will be smaller than any of the operands
-        if (word_addition_result + carry < shorter->m_words[i]) {
-            carry_out = 1;
-        }
-        if (carry) {
-            word_addition_result++;
-        }
-        carry = carry_out;
-        result.m_words.unchecked_append(word_addition_result);
-    }
-
-    for (size_t i = shorter->length(); i < longer->length(); ++i) {
-        u32 word_addition_result = longer->m_words[i] + carry;
-
-        carry = 0;
-        if (word_addition_result < longer->m_words[i]) {
-            carry = 1;
-        }
-        result.m_words.unchecked_append(word_addition_result);
-    }
-    if (carry) {
-        result.m_words.unchecked_append(carry);
-    }
-    return result;
-}
-
-/**
- * Complexity: O(N) where N is the number of words in the larger number
- */
-UnsignedBigInteger UnsignedBigInteger::minus(const UnsignedBigInteger& other) const
+FLATTEN UnsignedBigInteger UnsignedBigInteger::plus(const UnsignedBigInteger& other) const
 {
     UnsignedBigInteger result;
 
-    if (*this < other) {
-        return UnsignedBigInteger::create_invalid();
-    }
-
-    u8 borrow = 0;
-    auto own_length = length(), other_length = other.length();
-
-    result.m_words.ensure_capacity(own_length);
-
-    for (size_t i = 0; i < own_length; ++i) {
-        u32 other_word = (i < other_length) ? other.m_words[i] : 0;
-        i64 temp = static_cast<i64>(m_words[i]) - static_cast<i64>(other_word) - static_cast<i64>(borrow);
-        // If temp < 0, we had an underflow
-        borrow = (temp >= 0) ? 0 : 1;
-        if (temp < 0) {
-            temp += (UINT32_MAX + 1);
-        }
-        result.m_words.append(temp);
-    }
-
-    // This assertion should not fail, because we verified that *this>=other at the beginning of the function
-    ASSERT(borrow == 0);
+    add_without_allocation(*this, other, result);
 
     return result;
 }
 
-UnsignedBigInteger UnsignedBigInteger::shift_left(size_t num_bits) const
+FLATTEN UnsignedBigInteger UnsignedBigInteger::minus(const UnsignedBigInteger& other) const
 {
-    // We can only do shift operations on individual words
-    // where the shift amount is <= size of word (32).
-    // But we do know how to shift by a multiple of word size (e.g 64=32*2)
-    // So we first shift the result by how many whole words fit in 'num_bits'
-    UnsignedBigInteger temp_result = shift_left_by_n_words(num_bits / UnsignedBigInteger::BITS_IN_WORD);
+    UnsignedBigInteger result;
 
-    // And now we shift by the leftover amount of bits
-    num_bits %= UnsignedBigInteger::BITS_IN_WORD;
+    subtract_without_allocation(*this, other, result);
 
-    UnsignedBigInteger result(temp_result);
-
-    for (size_t i = 0; i < temp_result.length(); ++i) {
-        u32 current_word_of_temp_result = temp_result.shift_left_get_one_word(num_bits, i);
-        result.m_words[i] = current_word_of_temp_result;
-    }
-
-    // Shifting the last word can produce a carry
-    u32 carry_word = temp_result.shift_left_get_one_word(num_bits, temp_result.length());
-    if (carry_word != 0) {
-        result = result.plus(UnsignedBigInteger(carry_word).shift_left_by_n_words(temp_result.length()));
-    }
     return result;
 }
 
-/**
- * Complexity: O(N^2) where N is the number of words in the larger number
- * Multiplcation method:
- * An integer is equal to the sum of the powers of two
- * according to the indexes of its 'on' bits.
- * So to multiple x*y, we go over each '1' bit in x (say the i'th bit), 
- * and add y<<i to the result.
- */
+FLATTEN UnsignedBigInteger UnsignedBigInteger::shift_left(size_t num_bits) const
+{
+    UnsignedBigInteger output;
+    UnsignedBigInteger temp_result;
+    UnsignedBigInteger temp_plus;
+
+    shift_left_without_allocation(*this, num_bits, temp_result, temp_plus, output);
+
+    return output;
+}
+
 FLATTEN UnsignedBigInteger UnsignedBigInteger::multiplied_by(const UnsignedBigInteger& other) const
 {
     UnsignedBigInteger result;
-    // iterate all bits
-    for (size_t word_index = 0; word_index < length(); ++word_index) {
-        for (size_t bit_index = 0; bit_index < UnsignedBigInteger::BITS_IN_WORD; ++bit_index) {
-            // If the bit is off - skip over it
-            if (!(m_words[word_index] & (1 << bit_index)))
-                continue;
+    UnsignedBigInteger temp_shift_result;
+    UnsignedBigInteger temp_shift_plus;
+    UnsignedBigInteger temp_shift;
+    UnsignedBigInteger temp_plus;
 
-            const size_t shift_amount = word_index * UnsignedBigInteger::BITS_IN_WORD + bit_index;
-            auto shift_result = other.shift_left(shift_amount);
-            result = result.plus(shift_result);
-        }
-    }
+    multiply_without_allocation(*this, other, temp_shift_result, temp_shift_plus, temp_shift, temp_plus, result);
+
     return result;
 }
 
-/**
- * Complexity: O(N^2) where N is the number of words in the larger number
- * Division method:
- * We loop over the bits of the divisor, attempting to subtract divisor<<i from the dividend.
- * If the result is non-negative, it means that divisor*2^i "fits" in the dividend,
- * so we set the ith bit in the quotient and reduce divisor<<i from the dividend.
- * When we're done, what's left from the dividend is the remainder.
- */
 FLATTEN UnsignedDivisionResult UnsignedBigInteger::divided_by(const UnsignedBigInteger& divisor) const
 {
-    UnsignedBigInteger leftover_dividend(*this);
     UnsignedBigInteger quotient;
+    UnsignedBigInteger remainder;
 
-    // iterate all bits
-    for (int word_index = trimmed_length() - 1; word_index >= 0; --word_index) {
-        for (int bit_index = UnsignedBigInteger::BITS_IN_WORD - 1; bit_index >= 0; --bit_index) {
+    UnsignedBigInteger temp_shift_result;
+    UnsignedBigInteger temp_shift_plus;
+    UnsignedBigInteger temp_shift;
+    UnsignedBigInteger temp_minus;
 
-            const size_t shift_amount = word_index * UnsignedBigInteger::BITS_IN_WORD + bit_index;
-            UnsignedBigInteger divisor_shifted = divisor.shift_left(shift_amount);
+    divide_without_allocation(*this, divisor, temp_shift_result, temp_shift_plus, temp_shift, temp_minus, quotient, remainder);
 
-            UnsignedBigInteger temp_subtraction_result = leftover_dividend.minus(divisor_shifted);
-            if (!temp_subtraction_result.is_invalid()) {
-                leftover_dividend = temp_subtraction_result;
-                quotient.set_bit_inplace(shift_amount);
-            }
-        }
-    }
-    return UnsignedDivisionResult { quotient, leftover_dividend };
+    return UnsignedDivisionResult { quotient, remainder };
 }
 
 void UnsignedBigInteger::set_bit_inplace(size_t bit_index)
@@ -320,39 +235,231 @@ bool UnsignedBigInteger::operator<(const UnsignedBigInteger& other) const
     return false;
 }
 
-ALWAYS_INLINE UnsignedBigInteger UnsignedBigInteger::shift_left_by_n_words(const size_t number_of_words) const
+/**
+ * Complexity: O(N) where N is the number of words in the larger number
+ */
+void UnsignedBigInteger::add_without_allocation(
+    const UnsignedBigInteger& left,
+    const UnsignedBigInteger& right,
+    UnsignedBigInteger& output)
+{
+    const UnsignedBigInteger* const longer = (left.length() > right.length()) ? &left : &right;
+    const UnsignedBigInteger* const shorter = (longer == &right) ? &left : &right;
+
+    u8 carry = 0;
+
+    output.set_to_0();
+    output.m_words.ensure_capacity(longer->length() + 1);
+
+    for (size_t i = 0; i < shorter->length(); ++i) {
+        u32 word_addition_result = shorter->m_words[i] + longer->m_words[i];
+        u8 carry_out = 0;
+        // if there was a carry, the result will be smaller than any of the operands
+        if (word_addition_result + carry < shorter->m_words[i]) {
+            carry_out = 1;
+        }
+        if (carry) {
+            word_addition_result++;
+        }
+        carry = carry_out;
+        output.m_words.unchecked_append(word_addition_result);
+    }
+
+    for (size_t i = shorter->length(); i < longer->length(); ++i) {
+        u32 word_addition_result = longer->m_words[i] + carry;
+
+        carry = 0;
+        if (word_addition_result < longer->m_words[i]) {
+            carry = 1;
+        }
+        output.m_words.unchecked_append(word_addition_result);
+    }
+    if (carry) {
+        output.m_words.unchecked_append(carry);
+    }
+}
+
+/**
+ * Complexity: O(N) where N is the number of words in the larger number
+ */
+void UnsignedBigInteger::subtract_without_allocation(
+    const UnsignedBigInteger& left,
+    const UnsignedBigInteger& right,
+    UnsignedBigInteger& output)
+{
+    if (left < right) {
+        output.invalidate();
+        return;
+    }
+
+    u8 borrow = 0;
+    auto own_length = left.length();
+    auto other_length = right.length();
+
+    output.set_to_0();
+    output.m_words.ensure_capacity(own_length);
+
+    for (size_t i = 0; i < own_length; ++i) {
+        u32 other_word = (i < other_length) ? right.m_words[i] : 0;
+        i64 temp = static_cast<i64>(left.m_words[i]) - static_cast<i64>(other_word) - static_cast<i64>(borrow);
+        // If temp < 0, we had an underflow
+        borrow = (temp >= 0) ? 0 : 1;
+        if (temp < 0) {
+            temp += (UINT32_MAX + 1);
+        }
+        output.m_words.append(temp);
+    }
+
+    // This assertion should not fail, because we verified that *this>=other at the beginning of the function
+    ASSERT(borrow == 0);
+}
+
+[[gnu::flatten]] void UnsignedBigInteger::shift_left_without_allocation(
+    const UnsignedBigInteger& number,
+    size_t num_bits,
+    UnsignedBigInteger& temp_result,
+    UnsignedBigInteger& temp_plus,
+    UnsignedBigInteger& output)
+{
+    // We can only do shift operations on individual words
+    // where the shift amount is <= size of word (32).
+    // But we do know how to shift by a multiple of word size (e.g 64=32*2)
+    // So we first shift the result by how many whole words fit in 'num_bits'
+    shift_left_by_n_words(number, num_bits / UnsignedBigInteger::BITS_IN_WORD, temp_result);
+
+    // And now we shift by the leftover amount of bits
+    num_bits %= UnsignedBigInteger::BITS_IN_WORD;
+
+    output.set_to(temp_result);
+
+    for (size_t i = 0; i < temp_result.length(); ++i) {
+        u32 current_word_of_temp_result = shift_left_get_one_word(temp_result, num_bits, i);
+        output.m_words[i] = current_word_of_temp_result;
+    }
+
+    // Shifting the last word can produce a carry
+    u32 carry_word = shift_left_get_one_word(temp_result, num_bits, temp_result.length());
+    if (carry_word != 0) {
+
+        // output += (carry_word << temp_result.length())
+        // FIXME : Using temp_plus this way to transform carry_word into a bigint is not pretty.
+        temp_plus.set_to_0();
+        temp_plus.m_words.append(carry_word);
+        shift_left_by_n_words(temp_plus, temp_result.length(), temp_result);
+        add_without_allocation(output, temp_result, temp_plus);
+        output.set_to(temp_plus);
+    }
+}
+
+/**
+ * Complexity: O(N^2) where N is the number of words in the larger number
+ * Multiplcation method:
+ * An integer is equal to the sum of the powers of two
+ * according to the indexes of its 'on' bits.
+ * So to multiple x*y, we go over each '1' bit in x (say the i'th bit), 
+ * and add y<<i to the result.
+ */
+FLATTEN void UnsignedBigInteger::multiply_without_allocation(
+    const UnsignedBigInteger& left,
+    const UnsignedBigInteger& right,
+    UnsignedBigInteger& temp_shift_result,
+    UnsignedBigInteger& temp_shift_plus,
+    UnsignedBigInteger& temp_shift,
+    UnsignedBigInteger& temp_plus,
+    UnsignedBigInteger& output)
+{
+    output.set_to_0();
+
+    // iterate all bits
+    for (size_t word_index = 0; word_index < left.length(); ++word_index) {
+        for (size_t bit_index = 0; bit_index < UnsignedBigInteger::BITS_IN_WORD; ++bit_index) {
+            // If the bit is off - skip over it
+            if (!(left.m_words[word_index] & (1 << bit_index)))
+                continue;
+
+            const size_t shift_amount = word_index * UnsignedBigInteger::BITS_IN_WORD + bit_index;
+
+            // output += (right << shift_amount);
+            shift_left_without_allocation(right, shift_amount, temp_shift_result, temp_shift_plus, temp_shift);
+            add_without_allocation(output, temp_shift, temp_plus);
+            output.set_to(temp_plus);
+        }
+    }
+}
+
+/**
+ * Complexity: O(N^2) where N is the number of words in the larger number
+ * Division method:
+ * We loop over the bits of the divisor, attempting to subtract divisor<<i from the dividend.
+ * If the result is non-negative, it means that divisor*2^i "fits" in the dividend,
+ * so we set the ith bit in the quotient and reduce divisor<<i from the dividend.
+ * When we're done, what's left from the dividend is the remainder.
+ */
+FLATTEN void UnsignedBigInteger::divide_without_allocation(
+    const UnsignedBigInteger& numerator,
+    const UnsignedBigInteger& denominator,
+    UnsignedBigInteger& temp_shift_result,
+    UnsignedBigInteger& temp_shift_plus,
+    UnsignedBigInteger& temp_shift,
+    UnsignedBigInteger& temp_minus,
+    UnsignedBigInteger& quotient,
+    UnsignedBigInteger& remainder)
+{
+    quotient.set_to_0();
+    remainder.set_to(numerator);
+
+    // iterate all bits
+    for (int word_index = numerator.trimmed_length() - 1; word_index >= 0; --word_index) {
+        for (int bit_index = UnsignedBigInteger::BITS_IN_WORD - 1; bit_index >= 0; --bit_index) {
+            const size_t shift_amount = word_index * UnsignedBigInteger::BITS_IN_WORD + bit_index;
+            shift_left_without_allocation(denominator, shift_amount, temp_shift_result, temp_shift_plus, temp_shift);
+
+            subtract_without_allocation(remainder, temp_shift, temp_minus);
+            if (!temp_minus.is_invalid()) {
+                remainder.set_to(temp_minus);
+                quotient.set_bit_inplace(shift_amount);
+            }
+        }
+    }
+}
+
+ALWAYS_INLINE void UnsignedBigInteger::shift_left_by_n_words(
+    const UnsignedBigInteger& number,
+    const size_t number_of_words,
+    UnsignedBigInteger& output)
 {
     // shifting left by N words means just inserting N zeroes to the beginning of the words vector
-    UnsignedBigInteger result;
-
-    result.m_words.ensure_capacity(number_of_words + length());
+    output.set_to_0();
+    output.m_words.ensure_capacity(number_of_words + number.length());
 
     for (size_t i = 0; i < number_of_words; ++i) {
-        result.m_words.unchecked_append(0);
+        output.m_words.unchecked_append(0);
     }
-    for (size_t i = 0; i < length(); ++i) {
-        result.m_words.unchecked_append(m_words[i]);
+    for (size_t i = 0; i < number.length(); ++i) {
+        output.m_words.unchecked_append(number.m_words[i]);
     }
-    return result;
 }
 
 /**
  * Returns the word at a requested index in the result of a shift operation
  */
-ALWAYS_INLINE u32 UnsignedBigInteger::shift_left_get_one_word(const size_t num_bits, const size_t result_word_index) const
+ALWAYS_INLINE u32 UnsignedBigInteger::shift_left_get_one_word(
+    const UnsignedBigInteger& number,
+    const size_t num_bits,
+    const size_t result_word_index)
 {
     // "<= length()" (rather than length() - 1) is intentional,
     // The result inedx of length() is used when calculating the carry word
-    ASSERT(result_word_index <= length());
+    ASSERT(result_word_index <= number.length());
     ASSERT(num_bits <= UnsignedBigInteger::BITS_IN_WORD);
     u32 result = 0;
 
     // we need to check for "num_bits != 0" since shifting right by 32 is apparently undefined behaviour!
     if (result_word_index > 0 && num_bits != 0) {
-        result += m_words[result_word_index - 1] >> (UnsignedBigInteger::BITS_IN_WORD - num_bits);
+        result += number.m_words[result_word_index - 1] >> (UnsignedBigInteger::BITS_IN_WORD - num_bits);
     }
-    if (result_word_index < length() && num_bits < 32) {
-        result += m_words[result_word_index] << num_bits;
+    if (result_word_index < number.length() && num_bits < 32) {
+        result += number.m_words[result_word_index] << num_bits;
     }
     return result;
 }

--- a/Libraries/LibCrypto/BigInt/UnsignedBigInteger.h
+++ b/Libraries/LibCrypto/BigInt/UnsignedBigInteger.h
@@ -41,13 +41,12 @@ public:
     UnsignedBigInteger(u32 x) { m_words.append(x); }
 
     explicit UnsignedBigInteger(AK::Vector<u32, STARTING_WORD_SIZE>&& words)
-        : m_words(words)
+        : m_words(move(words))
     {
     }
 
-    UnsignedBigInteger() { }
+    UnsignedBigInteger() {}
 
-    static UnsignedBigInteger from_base10(const String& str);
     static UnsignedBigInteger create_invalid();
 
     static UnsignedBigInteger import_data(const AK::StringView& data) { return import_data((const u8*)data.characters_without_null_termination(), data.length()); }
@@ -60,30 +59,30 @@ public:
         return export_data(buffer);
     }
 
+    static UnsignedBigInteger from_base10(const String& str);
+    String to_base10() const;
+
     const AK::Vector<u32, STARTING_WORD_SIZE>& words() const { return m_words; }
+
+    void invalidate() { m_is_invalid = true; }
+
+    bool is_invalid() const { return m_is_invalid; }
+
+    size_t length() const { return m_words.size(); }
+    // The "trimmed length" is the number of words after trimming leading zeroed words
+    size_t trimmed_length() const;
 
     UnsignedBigInteger plus(const UnsignedBigInteger& other) const;
     UnsignedBigInteger minus(const UnsignedBigInteger& other) const;
-    UnsignedBigInteger multiplied_by(const UnsignedBigInteger& other) const;
     UnsignedBigInteger shift_left(size_t num_bits) const;
-
+    UnsignedBigInteger multiplied_by(const UnsignedBigInteger& other) const;
     UnsignedDivisionResult divided_by(const UnsignedBigInteger& divisor) const;
 
     void set_bit_inplace(size_t bit_index);
 
-    size_t length() const { return m_words.size(); }
-
-    // The "trimmed length" is the number of words after trimming leading zeroed words
-    size_t trimmed_length() const;
-
     bool operator==(const UnsignedBigInteger& other) const;
     bool operator!=(const UnsignedBigInteger& other) const;
     bool operator<(const UnsignedBigInteger& other) const;
-
-    void invalidate() { m_is_invalid = true; }
-    bool is_invalid() const { return m_is_invalid; }
-
-    String to_base10() const;
 
 private:
     ALWAYS_INLINE UnsignedBigInteger shift_left_by_n_words(const size_t number_of_words) const;

--- a/Libraries/LibCrypto/BigInt/UnsignedBigInteger.h
+++ b/Libraries/LibCrypto/BigInt/UnsignedBigInteger.h
@@ -64,6 +64,8 @@ public:
 
     const AK::Vector<u32, STARTING_WORD_SIZE>& words() const { return m_words; }
 
+    void set_to_0();
+    void set_to(const UnsignedBigInteger& other);
     void invalidate() { m_is_invalid = true; }
 
     bool is_invalid() const { return m_is_invalid; }
@@ -80,13 +82,19 @@ public:
 
     void set_bit_inplace(size_t bit_index);
 
+    static void add_without_allocation(const UnsignedBigInteger& left, const UnsignedBigInteger& right, UnsignedBigInteger& output);
+    static void subtract_without_allocation(const UnsignedBigInteger& left, const UnsignedBigInteger& right, UnsignedBigInteger& output);
+    static void shift_left_without_allocation(const UnsignedBigInteger& number, size_t bits_to_shift_by, UnsignedBigInteger& temp_result, UnsignedBigInteger& temp_plus, UnsignedBigInteger& output);
+    static void multiply_without_allocation(const UnsignedBigInteger& left, const UnsignedBigInteger& right, UnsignedBigInteger& temp_shift_result, UnsignedBigInteger& temp_shift_plus, UnsignedBigInteger& temp_shift, UnsignedBigInteger& temp_plus, UnsignedBigInteger& output);
+    static void divide_without_allocation(const UnsignedBigInteger& numerator, const UnsignedBigInteger& denominator, UnsignedBigInteger& temp_shift_result, UnsignedBigInteger& temp_shift_plus, UnsignedBigInteger& temp_shift, UnsignedBigInteger& temp_minus, UnsignedBigInteger& quotient, UnsignedBigInteger& remainder);
+
     bool operator==(const UnsignedBigInteger& other) const;
     bool operator!=(const UnsignedBigInteger& other) const;
     bool operator<(const UnsignedBigInteger& other) const;
 
 private:
-    ALWAYS_INLINE UnsignedBigInteger shift_left_by_n_words(const size_t number_of_words) const;
-    ALWAYS_INLINE u32 shift_left_get_one_word(const size_t num_bits, const size_t result_word_index) const;
+    ALWAYS_INLINE static void shift_left_by_n_words(const UnsignedBigInteger& number, size_t number_of_words, UnsignedBigInteger& output);
+    ALWAYS_INLINE static u32 shift_left_get_one_word(const UnsignedBigInteger& number, size_t num_bits, size_t result_word_index);
 
     static constexpr size_t BITS_IN_WORD = 32;
     AK::Vector<u32, STARTING_WORD_SIZE> m_words;

--- a/Libraries/LibCrypto/BigInt/UnsignedBigInteger.h
+++ b/Libraries/LibCrypto/BigInt/UnsignedBigInteger.h
@@ -65,6 +65,7 @@ public:
     const AK::Vector<u32, STARTING_WORD_SIZE>& words() const { return m_words; }
 
     void set_to_0();
+    void set_to(u32 other);
     void set_to(const UnsignedBigInteger& other);
     void invalidate() { m_is_invalid = true; }
 
@@ -87,6 +88,7 @@ public:
     static void shift_left_without_allocation(const UnsignedBigInteger& number, size_t bits_to_shift_by, UnsignedBigInteger& temp_result, UnsignedBigInteger& temp_plus, UnsignedBigInteger& output);
     static void multiply_without_allocation(const UnsignedBigInteger& left, const UnsignedBigInteger& right, UnsignedBigInteger& temp_shift_result, UnsignedBigInteger& temp_shift_plus, UnsignedBigInteger& temp_shift, UnsignedBigInteger& temp_plus, UnsignedBigInteger& output);
     static void divide_without_allocation(const UnsignedBigInteger& numerator, const UnsignedBigInteger& denominator, UnsignedBigInteger& temp_shift_result, UnsignedBigInteger& temp_shift_plus, UnsignedBigInteger& temp_shift, UnsignedBigInteger& temp_minus, UnsignedBigInteger& quotient, UnsignedBigInteger& remainder);
+    static void divide_u16_without_allocation(const UnsignedBigInteger& numerator, u32 denominator, UnsignedBigInteger& quotient, UnsignedBigInteger& remainder);
 
     bool operator==(const UnsignedBigInteger& other) const;
     bool operator!=(const UnsignedBigInteger& other) const;

--- a/Libraries/LibCrypto/NumberTheory/ModularFunctions.h
+++ b/Libraries/LibCrypto/NumberTheory/ModularFunctions.h
@@ -39,7 +39,6 @@ static auto ModularInverse(const UnsignedBigInteger& a_, const UnsignedBigIntege
         return { 1 };
 
     UnsignedBigInteger one { 1 };
-    UnsignedBigInteger two { 2 };
     UnsignedBigInteger temp_1;
     UnsignedBigInteger temp_2;
     UnsignedBigInteger temp_3;
@@ -82,11 +81,11 @@ static auto ModularInverse(const UnsignedBigInteger& a_, const UnsignedBigIntege
                 }
 
                 // u /= 2
-                UnsignedBigInteger::divide_without_allocation(u, two, temp_1, temp_2, temp_3, temp_4, temp_quotient, temp_remainder);
+                UnsignedBigInteger::divide_u16_without_allocation(u, 2, temp_quotient, temp_remainder);
                 u.set_to(temp_quotient);
 
                 // d /= 2
-                UnsignedBigInteger::divide_without_allocation(d, two, temp_1, temp_2, temp_3, temp_4, temp_quotient, temp_remainder);
+                UnsignedBigInteger::divide_u16_without_allocation(d, 2, temp_quotient, temp_remainder);
                 d.set_to(temp_quotient);
             }
         }
@@ -107,11 +106,11 @@ static auto ModularInverse(const UnsignedBigInteger& a_, const UnsignedBigIntege
             }
 
             // v /= 2
-            UnsignedBigInteger::divide_without_allocation(v, two, temp_1, temp_2, temp_3, temp_4, temp_quotient, temp_remainder);
+            UnsignedBigInteger::divide_u16_without_allocation(v, 2, temp_quotient, temp_remainder);
             v.set_to(temp_quotient);
 
             // x /= 2
-            UnsignedBigInteger::divide_without_allocation(x, two, temp_1, temp_2, temp_3, temp_4, temp_quotient, temp_remainder);
+            UnsignedBigInteger::divide_u16_without_allocation(x, 2, temp_quotient, temp_remainder);
             x.set_to(temp_quotient);
         }
     }
@@ -129,7 +128,6 @@ static auto ModularPower(const UnsignedBigInteger& b, const UnsignedBigInteger& 
     UnsignedBigInteger ep { e };
     UnsignedBigInteger base { b };
     UnsignedBigInteger exp { 1 };
-    UnsignedBigInteger two { 2 };
 
     UnsignedBigInteger temp_1;
     UnsignedBigInteger temp_2;
@@ -151,7 +149,7 @@ static auto ModularPower(const UnsignedBigInteger& b, const UnsignedBigInteger& 
         }
 
         // ep = ep / 2;
-        UnsignedBigInteger::divide_without_allocation(ep, two, temp_1, temp_2, temp_3, temp_4, temp_quotient, temp_remainder);
+        UnsignedBigInteger::divide_u16_without_allocation(ep, 2, temp_quotient, temp_remainder);
         ep.set_to(temp_quotient);
 
         // base = (base * base) % m;

--- a/Userland/test-crypto.cpp
+++ b/Userland/test-crypto.cpp
@@ -1341,7 +1341,7 @@ void bigint_subtraction()
         PASS;
     }
     {
-        I_TEST((BigInteger | Subtraction Regerssion 1));
+        I_TEST((BigInteger | Subtraction Regression 1));
         auto num = Crypto::UnsignedBigInteger { 1 }.shift_left(256);
         if (num.minus(1).words() == Vector<u32> { 4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 4294967295, 0 }) {
             PASS;
@@ -1354,7 +1354,7 @@ void bigint_subtraction()
 void bigint_multiplication()
 {
     {
-        I_TEST((BigInteger | Simple Multipliction));
+        I_TEST((BigInteger | Simple Multiplication));
         Crypto::UnsignedBigInteger num1(8);
         Crypto::UnsignedBigInteger num2(251);
         Crypto::UnsignedBigInteger result = num1.multiplied_by(num2);

--- a/Userland/test-crypto.cpp
+++ b/Userland/test-crypto.cpp
@@ -12,6 +12,7 @@
 #include <LibLine/Editor.h>
 #include <LibTLS/TLSv12.h>
 #include <stdio.h>
+#include <time.h>
 
 static const char* secret_key = "WellHelloFreinds";
 static const char* suite = nullptr;
@@ -23,6 +24,10 @@ static bool interactive = false;
 static bool run_tests = false;
 static int port = 443;
 
+static struct timeval start_time {
+    0, 0
+};
+static struct timezone tz;
 static bool encrypting = true;
 
 constexpr const char* DEFAULT_DIGEST_SUITE { "HMAC-SHA256" };
@@ -381,8 +386,23 @@ auto main(int argc, char** argv) -> int
     {                                     \
         printf("Testing " #thing "... "); \
         fflush(stdout);                   \
+        gettimeofday(&start_time, &tz);   \
     }
-#define PASS printf("PASS\n")
+#define PASS                                                     \
+    {                                                            \
+        struct timeval end_time {                                \
+            0, 0                                                 \
+        };                                                       \
+        gettimeofday(&end_time, &tz);                            \
+        time_t interval_s = end_time.tv_sec - start_time.tv_sec; \
+        suseconds_t interval_us = end_time.tv_usec;              \
+        if (interval_us < start_time.tv_usec) {                  \
+            interval_s += 1;                                     \
+            interval_us += 1000000;                              \
+        }                                                        \
+        interval_us -= start_time.tv_usec;                       \
+        printf("PASS %llds %dus\n", interval_s, interval_us);    \
+    }
 #define FAIL(reason) printf("FAIL: " #reason "\n")
 
 ByteBuffer operator""_b(const char* string, size_t length)
@@ -1063,10 +1083,11 @@ void bigint_test_number_theory()
 {
     {
         I_TEST((Number Theory | Modular Inverse));
-        if (Crypto::NumberTheory::ModularInverse(7, 87) == 25)
+        if (Crypto::NumberTheory::ModularInverse(7, 87) == 25) {
             PASS;
-        else
+        } else {
             FAIL(Invalid result);
+        }
     }
     {
         I_TEST((Number Theory | Modular Power));
@@ -1227,9 +1248,9 @@ void bigint_test_fibo500()
         I_TEST((BigInteger | Fibonacci500));
         bool pass = (bigint_fibonacci(500).words() == AK::Vector<u32> { 315178285, 505575602, 1883328078, 125027121, 3649625763, 347570207, 74535262, 3832543808, 2472133297, 1600064941, 65273441 });
 
-        if (pass)
+        if (pass) {
             PASS;
-        else {
+        } else {
             FAIL(Incorrect Result);
         }
     }


### PR DESCRIPTION
This PR expands the API of UnsignedBigInteger to include :

- Static non-allocating add/subtract/multiply/divide/shift operations
- Special cases for operations between a BigInt and a small number (currently implemented : `divide_by_u16`)

These improvements are then used in ModularFunction to improve performances.

The method signatures are very unwieldy, but contain everything required to prevent allocations. Names can be reworked/changed as needed !

This PR also includes a bookkeeping commit (added a missing `move()`, fixed a typo in the tests names, and moved some methods around in the UnsignedBigInteger to make them thematically closer).

Here are the performance improvements (computed very professionally by sitting next to the computer with a timer and hitting it when the test ends) :

| Test | Original code | Using `without_alloc` variants |
|----------------------------|----------------|-----------------------|
| RSA PKCS #1 1.5 Encryption | 6mn 15s | 4mn 03s (-35%) |
| RSA Encrypt | 5mn 22s | 4mn 24s (-12%) |

Here are the top 4 methods with self-hits (inverted tree) during a 5-second `profile` run in the middle of the `RSA PKCS #1 1.5 Encryption` test :

| Method | Original code | Using `without_alloc` variants |
|----------------------------|----------------|-----------------------|
| `multiply_by{_without_allocation}` | 1182 | 1702 |
| `divide_by{_without_allocation}` | 1289 | 1498 |
| `malloc` | 1086 | 31 |
| `free` | 1085 | 22 |